### PR TITLE
Refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ node_js:
 script:
 - yarn lint
 - yarn test
+- yarn build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./index.js",
   "license": "MIT",
   "scripts": {
-    "test": "webpack --mode development && mocha --compilers js:babel-core/register --require babel-polyfill",
+    "test": "mocha --compilers js:babel-core/register --require babel-polyfill",
     "lint": "eslint --ext .js src test/unit/specs test/e2e/specs",
     "patch-release": "webpack --mode development && npm version patch && npm publish && git push --follow-tags",
     "minor-release": "webpack --mode development && npm version minor && npm publish && git push --follow-tags",
@@ -34,7 +34,7 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "mocha": "^5.0.0",
-    "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14"
+    "webpack": "^4.29.1",
+    "webpack-cli": "2.0.14"
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,21 @@
+import castArray from 'lodash/castArray'
+
+// Return first item in array
+export const ensureIsSingle =
+    prop => prop && Array.isArray(prop) ? prop[0] : prop
+
+// Find type of object given list of defined types
+// Returns String type
+export function findObjectType (obj = {}, definitions = []) {
+  if (!obj.type) return
+
+  let types = castArray(obj.type)
+    .map(typ => typ['@id'] || typ)
+
+  return definitions.find(val => types.indexOf(val) > -1)
+}
+
+// Remove wrapper from API response
+// Returns items property if exists
+export const stripWrapper =
+    res => res && res.items ? res.items : res

--- a/test/test-getter.js
+++ b/test/test-getter.js
@@ -1,14 +1,15 @@
 /* eslint-env node, mocha */
-import piton from '../src/api-getter.js'
-var assert = require('assert')
-const API_DEFINITIONS = require('./api-definitions.json')
+import piton from '../src/api-getter'
+import assert from 'assert'
+import API_DEFINITIONS from './api-definitions.json'
 
 describe('Api Getter', function () {
   it('Should get a result', async function () {
     this.timeout(5000)
     const testAPI = piton.getAPI(API_DEFINITIONS)
-    let res = await testAPI.getAPI('http://ea-cde-pub.epimorphics.net/catchment-planning/so/WaterBody/GB105033042700.json')
+    let res = await testAPI.getAPI('http://environment.data.gov.uk/catchment-planning/so/WaterBody/GB105033042700')
     res = res[0]
+
     assert.equal('WaterBody', res.slug)
     assert.ok(Array.isArray(res.characteristics))
     assert.equal('Bottisham Lode - Quy Water', res.label)
@@ -17,8 +18,9 @@ describe('Api Getter', function () {
   it('Should download multiple results with one getter', async function () {
     this.timeout(5000)
     const testAPI = piton.getAPI(API_DEFINITIONS)
-    let res1 = await testAPI.getAPI('http://ea-cde-pub.epimorphics.net/catchment-planning/so/WaterBody/GB105033042700.json')
-    let res2 = await testAPI.getAPI('http://ea-cde-pub.epimorphics.net/catchment-planning/so/WaterBody/GB105033042750.json')
+    let res1 = await testAPI.getAPI('http://environment.data.gov.uk/catchment-planning/so/WaterBody/GB105033042700')
+    let res2 = await testAPI.getAPI('http://environment.data.gov.uk/catchment-planning/so/WaterBody/GB105033042750')
+
     assert.equal('Bottisham Lode - Quy Water', res1[0].label)
     assert.equal('Cam', res2[0].label)
   })

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -1,17 +1,16 @@
 /* eslint-env node, mocha */
-var assert = require('assert')
-const assertThrows = require('assert-throws-async')
-var checker = require('../src/api-parser.js')
-const API_DEFINITIONS = require('./api-definitions.json')
+import assert from 'assert'
+import assertThrows from 'assert-throws-async'
+import * as checker from '../src/api-parser'
+import { ensureIsSingle, stripWrapper } from '../src/util'
+import API_DEFINITIONS from './api-definitions.json'
 
-const riverBasinDistrict = require('./data/12.json')
-const managementCatchment = require('./data/3049.json')
-const operationalCatchment = require('./data/3216.json')
-const waterbody = require('./data/GB109053027530.json')
+import riverBasinDistrict from './data/12.json'
+import managementCatchment from './data/3049.json'
+import operationalCatchment from './data/3216.json'
+import waterbody from './data/GB109053027530.json'
 
-var _ = require('lodash')
-
-// var axios = require('axios')
+import _ from 'lodash'
 
 // Perform utility automatically based on type asked for
 
@@ -23,50 +22,9 @@ var _ = require('lodash')
 // Can it simplify complex properties? Lang tags for example.
 
 describe('Api Checker', function () {
-  describe('#findObjectType()', function () {
-    it('should return empty when the value is not present', function () {
-      let obj = {type: {'@id': 'http://www.example.com'}}
-      assert.equal(undefined, checker.findObjectType(obj, ['']))
-    })
-    it('should return id when the value is present', function () {
-      let obj = {type: {'@id': 'http://www.example.com'}}
-      assert.equal(obj.type['@id'], checker.findObjectType(obj, ['http://www.example.com']))
-    })
-  })
-
-  describe('#ensureIsArray()', function () {
-    it('should return same array if passed array', function () {
-      let arr = [1, 2, 3, 4, 5, 6]
-      assert.equal(arr, checker.ensureIsArray(arr))
-    })
-    it('should return object wrapped in array if passed object', function () {
-      let obj = {'foo': 'bar'}
-      assert.deepEqual([obj], checker.ensureIsArray(obj))
-    })
-    it('should return primitive wrapped in array if passed primitive', function () {
-      let obj = 1
-      assert.deepEqual([obj], checker.ensureIsArray(obj))
-    })
-  })
-
-  describe('#ensureIsSingle()', function () {
-    it('should return same object if passed object', function () {
-      let obj = {'foo': 'bar'}
-      assert.equal(obj, checker.ensureIsSingle(obj))
-    })
-    it('should return object unwrapped from array if passed object', function () {
-      let obj = {'foo': 'bar'}
-      assert.deepEqual(obj, checker.ensureIsSingle([obj]))
-    })
-    it('should return primitive if passed primitive', function () {
-      let obj = 1
-      assert.deepEqual(obj, checker.ensureIsSingle([obj]))
-    })
-  })
-
   describe('#processAPIResponse()', function () {
     describe('general', function () {
-      let proto = checker.ensureIsSingle(checker.stripWrapper(_.cloneDeep(riverBasinDistrict)))
+      let proto = ensureIsSingle(stripWrapper(_.cloneDeep(riverBasinDistrict)))
 
       it('should work for single values', async function () {
         let processed = await checker.processAPIResponse(proto, API_DEFINITIONS)
@@ -94,13 +52,9 @@ describe('Api Checker', function () {
         this.timeout(10 * 1000)
         const myDefs = {
           'http://environment.data.gov.uk/catchment-planning/def/water-framework-directive/RiverBasinDistrict': {
-            'statics': {
-              type: []
-            },
-            'props': {
-              'type': 'type'
-            },
-            'required': ['type']
+            statics: { type: [] },
+            props: { type: 'type' },
+            required: ['type']
           }
         }
         let processed = await checker.processAPIResponse(_.cloneDeep(proto), myDefs)
@@ -109,7 +63,7 @@ describe('Api Checker', function () {
     })
 
     describe('riverBasinDistrict', function () {
-      let proto = checker.ensureIsSingle(checker.stripWrapper(_.cloneDeep(riverBasinDistrict)))
+      let proto = ensureIsSingle(stripWrapper(_.cloneDeep(riverBasinDistrict)))
 
       it('should add type and slug', async function () {
         let processed = await checker.processAPIResponse(proto, API_DEFINITIONS)
@@ -124,7 +78,7 @@ describe('Api Checker', function () {
     })
 
     describe('management Catchment', function () {
-      let proto = checker.ensureIsSingle(checker.stripWrapper(_.cloneDeep(managementCatchment)))
+      let proto = ensureIsSingle(stripWrapper(_.cloneDeep(managementCatchment)))
 
       it('should add type and slug', async function () {
         let processed = await checker.processAPIResponse(_.cloneDeep(proto), API_DEFINITIONS)
@@ -139,7 +93,7 @@ describe('Api Checker', function () {
     })
 
     describe('operational Catchment', function () {
-      let proto = checker.ensureIsSingle(checker.stripWrapper(_.cloneDeep(operationalCatchment)))
+      let proto = ensureIsSingle(stripWrapper(_.cloneDeep(operationalCatchment)))
 
       it('should add type and slug', async function () {
         let processed = await checker.processAPIResponse(_.cloneDeep(proto), API_DEFINITIONS)
@@ -154,7 +108,7 @@ describe('Api Checker', function () {
     })
 
     describe('waterBody', function () {
-      let proto = checker.ensureIsSingle(checker.stripWrapper(_.cloneDeep(waterbody)))
+      let proto = ensureIsSingle(stripWrapper(_.cloneDeep(waterbody)))
 
       it('should add type and slug', async function () {
         let processed = await checker.processAPIResponse(_.cloneDeep(proto), API_DEFINITIONS)

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -1,0 +1,42 @@
+/* eslint-env node, mocha */
+import assert from 'assert'
+import { ensureIsSingle, findObjectType, stripWrapper } from '../src/util'
+
+describe('Utilities', function () {
+  describe('#findObjectType()', function () {
+    it('should return empty when the value is not present', function () {
+      let obj = { type: { '@id': 'http://www.example.com' } }
+      assert.equal(undefined, findObjectType(obj, ['']))
+    })
+    it('should return id when the value is present', function () {
+      let obj = { type: { '@id': 'http://www.example.com' } }
+      assert.equal(obj.type['@id'], findObjectType(obj, ['http://www.example.com']))
+    })
+  })
+
+  describe('#ensureIsSingle()', function () {
+    it('should return same object if passed object', function () {
+      let obj = { foo: 'bar' }
+      assert.equal(obj, ensureIsSingle(obj))
+    })
+    it('should return object unwrapped from array if passed object', function () {
+      let obj = { foo: 'bar' }
+      assert.deepEqual(obj, ensureIsSingle([obj]))
+    })
+    it('should return primitive if passed primitive', function () {
+      let obj = 1
+      assert.deepEqual(obj, ensureIsSingle([obj]))
+    })
+  })
+
+  describe('#stripWrapper()', function () {
+    it('Removes data from wrapper', function () {
+      let obj = { items: [ 'a', 'b', 'c' ] }
+      assert.equal(obj.items, stripWrapper(obj))
+    })
+    it('Leaves unwrapped object intact', function () {
+      let obj = { foo: 'bar' }
+      assert.equal(obj, stripWrapper(obj))
+    })
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,8 +10,8 @@ module.exports = {
       }
     ]
   },
-  'entry': ['babel-polyfill', './src/'],
-  'output': {
-    'libraryTarget': 'commonjs'
+  entry: ['babel-polyfill', './src/'],
+  output: {
+    library: 'commonjs'
   }
 }


### PR DESCRIPTION
## Modified

- _src_
  - _api-getter.js_
    - implement es6 imports
    - add jsdoc
    - remove promise piping for better performance
  - _api-parser.js_
    - implement es6 imports
    - shake lodash dependencies
    - migrate utility function into dedicated module
    - add jsdoc
    - add loop to itereate over definitions to speed up
    - async/await automatically returns a promise, so no need to wrap it in a `new promise(...)`
    - removed promise piping for better performance
    - depriciated some utility functions, in favour of lodash and inline
- _test_
  - _test-getter.js_
    - implement es6 imports
    - fix getter test to use updated urls
  - _test-parser.js_
    - implement es6 imports
    - migrate util tests into own file
    - unquote props
- _/_
  - _package.json_
    - update dependencies
    - remove build from tests
  - _.travis.yml_
    - update to include a build step
  - _webpack.config.js_
    - remove quotes from props

## Adding

- _src/util.js_
  - migrate utilites from parser
  - depriciated some utility functions, in favour of lodash
- _test/test-util.js_
  - migrate tests from test-parser